### PR TITLE
docker: install iputils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ COPY api_monitor.sh /api_monitor.sh
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
       bash \
+      iputils \
       jq \
       libstdc++ \
     && apk add --no-cache --virtual .build-deps \


### PR DESCRIPTION
This solves: "ping: permission denied (are you root?)"

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>