### PR TITLE
Add curl in container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk add --no-cache \
       jq \
       libstdc++ \
       openssh-client \
+      curl \
     && apk add --no-cache --virtual .build-deps \
       build-base \
       libffi-dev \


### PR DESCRIPTION
`curl` is used inside of the `api_monitor.sh` script, so it should be added to the container image.

Signed-off-by: Joshua Mühlfort <muehlfort@gonicus.de>