### PR TITLE
Remove explicit date in influxdb writes

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -837,7 +837,7 @@ ostackcmd_id()
   if test -n "$GRAFANA"; then
       # log time / rc to grafana
       rc2grafana $RC
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC $(date +%s%N)" >> grafana.log
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC" >> grafana.log
   fi
 
   if test $RC != 0 -a -z "$IGNORE_ERRORS"; then
@@ -860,7 +860,7 @@ ostackcmd_id()
     if test -n "$GRAFANA"; then
       # log time / rc to grafana
       rc2grafana $RC
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC $(date +%s%N)" >> grafana.log
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC" >> grafana.log
     fi
     if test $RC != 0 -a -z "$IGNORE_ERRORS"; then
       sendalarm $RC "$*" "$RESP" $TIMEOUT
@@ -926,7 +926,7 @@ ostackcmd_tm()
     rc2grafana $RC
     # Note: We log untranslated commands to grafana here, for continuity reasons
     # (This is why we do translation in the first place ...)
-    curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC $(date +%s%N)" >> grafana.log
+    curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=$1,method=$2 duration=$TIM,return_code=$GRC" >> grafana.log
   fi
   # TODO: Implement retry for HTTP 409 similar to ostackcmd_id
 
@@ -1156,7 +1156,7 @@ waitResources()
         if test -n "$GRAFANA"; then
           # log time / rc to grafana
           if test $STE -ge 2; then RC=0; else RC=$STE; fi
-          curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=$COMP1 duration=$TM,return_code=$RC $(date +%s%N)" >> grafana.log
+          curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=$COMP1 duration=$TM,return_code=$RC" >> grafana.log
         fi
         unset SLIST[$i]
       fi
@@ -1260,7 +1260,7 @@ waitlistResources()
           if test -n "$GRAFANA"; then
             # log time / rc to grafana
             if test $STE -ge 2; then RC=0; else RC=$STE; fi
-            curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=$COMP1 duration=$TM,return_code=$RC $(date +%s%N)" >> grafana.log
+            curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=$COMP1 duration=$TM,return_code=$RC" >> grafana.log
           fi
         fi
       fi
@@ -1334,7 +1334,7 @@ waitdelResources()
       if test -n "$GRAFANA"; then
         # log time / rc to grafana
         rc2grafana $RC
-        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=DEL duration=$TM,return_code=$GRC $(date +%s%N)" >> grafana.log
+        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=wait$RNM,method=DEL duration=$TM,return_code=$GRC" >> grafana.log
       fi
       #echo -en "WaitDel $RNM: $STATSTR\r"
     done
@@ -2353,7 +2353,7 @@ wait222()
     fi
     if test -n "$GRAFANA"; then
       TIM=$(($(date +%s)-$ST))
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=JHVM$JHNO duration=$TIM,return_code=$perr $(date +%s%N)" >> grafana.log
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=JHVM$JHNO duration=$TIM,return_code=$perr" >> grafana.log
     fi
     if [ $ctr -ge $MAXWAIT ]; then
       # It does not make sense to wait for machines behind JH if JH is not reachable
@@ -2395,7 +2395,7 @@ $OSTACKRESP" 0
       MAXWAIT=42
       if test -n "$GRAFANA"; then
         TIM=$(($(date +%s)-$ST))
-        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=VM$JHNO:$pno duration=$TIM,return_code=$verr $(date +%s%N)" >> grafana.log
+        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=VM$JHNO:$pno duration=$TIM,return_code=$verr" >> grafana.log
       fi
       let vmno+=1
     done
@@ -2503,7 +2503,7 @@ testjhinet()
 # Don't generate entry for success here, we'll test this again in wait222, which records the success/time
     if test -n "$GRAFANA" -a $R != 0; then
       TIM=$(($(date +%s)-$ST))
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=JHVM$JHNO duration=$TIM,return_code=$R $(date +%s%N)" >/dev/null
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=ssh,method=JHVM$JHNO duration=$TIM,return_code=$R" >/dev/null
     fi
   done
   if test $RC = 0; then
@@ -2542,7 +2542,7 @@ EOT
       echo -en "${BOLD} $BENCH s${NORM}"
       if test -n "$LOGFILE"; then echo -n " $BENCH s" >> $LOGFILE; fi
       if test -n "$GRAFANA"; then
-        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=4000pi,method=JHVM$JHNO duration=$BENCH,return_code=0 $(date +%s%N)" >/dev/null
+        curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=4000pi,method=JHVM$JHNO duration=$BENCH,return_code=0" >/dev/null
       fi
       PITIME+=($BENCH)
     done
@@ -2730,8 +2730,8 @@ EOT
     if test -n "$LOGFILE"; then echo -e "IPerf3: ${IPS[$NONETS]}-${TGT}: $SENDBW Mbps $RECVBW Mbps $HTUIL $RUTIL" >>$LOGFILE; fi
     BANDWIDTH+=($SENDBW $RECVBW)
     if test -n "$GRAFANA"; then
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=iperf3,method=s$VM duration=$SENDBW,return_code=0 $(date +%s%N)" >/dev/null
-      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=iperf3,method=r$VM duration=$RECVBW,return_code=0 $(date +%s%N)" >/dev/null
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=iperf3,method=s$VM duration=$SENDBW,return_code=0" >/dev/null
+      curl -si -XPOST 'http://localhost:8186/write?db=cicd' --data-binary "$GRAFANANM,cmd=iperf3,method=r$VM duration=$RECVBW,return_code=0" >/dev/null
     fi
   done
   echo -en "\b"


### PR DESCRIPTION
The busybox `date` yields different results than the GNU coreutils `date`. Specifically, it does not seem to expand `%N` to nanoseconds, which seems to cause incorrect time mappings inside of telegraf.

Omitting the date altogether makes telegraf (in the version that I tested) adding it automatically, which should be fine for this use case.

CC @berendt @garloff 

Signed-off-by: Joshua Mühlfort <muehlfort@gonicus.de>