### PR TITLE
Ignore tagging when finding routers and lbs to delete.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -651,7 +651,8 @@ translate()
   shift
   CMD=${1##*-}
   # External nets are not managed by us and thus not tagged; ports created via nova are neither
-  if test $ORIGCMD == neutron && test $CMD == create -o $CMD == list && test "$1" != "net-external-list" -a "$1" != "port-list"; then
+  # (Also routers and loadbalancer may not be tagged reliably?)
+  if test $ORIGCMD == neutron && test $CMD == create -o $CMD == list && test "$1" != "net-external-list" -a "$1" != "port-list" -a "$1" != "router-list" -a "$1" != "lbaas-loadbalancer-list"; then
     MYTAG="$TAGARG"
   fi
   if test "$CMD" == "$1"; then


### PR DESCRIPTION
For some reason we observe LBs and Routers that lack the tags
they should have received during creation.
This will need to be investigated another day.
For now just don't filter by tag for those resources, as we
can reliably identify them by name.

Signed-off-by: Kurt Garloff <scs@garloff.de>