### PR TITLE
Find ports leaked by octavia and delete them.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3167,6 +3167,14 @@ waitnetgone()
   PORTS=( $(findres "" neutron port-list) )
   IGNORE_ERRORS=1
   deletePorts
+  # FIXME: We occasionally leaks ports from octavia
+  if test -n "$LOADBALANCER"; then
+    SUBNETS=( $(findres "" neutron subnet-list) )
+    for sub in "$SUBNETS"; do
+      PORTS=( $(findres "octavia-lb-vrrp" neutron port-list --fixed-ip subnet=$sub) )
+      deletePorts
+    done
+  fi
   unset IGNORE_ERRORS
   echo -n "Wait for subnets/nets to disappear: "
   SUBNETS=( $(findres "" neutron subnet-list) )


### PR DESCRIPTION
Ocatvia occasionally leaks ports. We currently don't handle them, so
they stay around and prevent the cleanup of subnets and networks, thus
potentially making us run against the network quota.

Identify and delete them.

Signed-off-by: Kurt Garloff <kurt@garloff.de>