### PR TITLE
Kill backends and check LB effectiveness.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2245,7 +2245,7 @@ testLBs()
   ERRREASON=""
   echo -n "LBaaS2 "
   if test "$TCP_LB" = "1"; then echo -n "(TCP) "; PROTO=TCP; unset SESSPERS; unset URLPATH
-  else echo -n "(HTTP) "; PROTO=HTTP; SESSPERS="--session persistence type=HTTP_COOKIE"; URLPATH="--url-path /hostname"; fi
+  else echo -n "(HTTP) "; PROTO=HTTP; SESSPERS="--session-persistence type=HTTP_COOKIE"; URLPATH="--url-path /hostname"; fi
   createResources 1 LBSTATS POOL LBAAS NONE "" id $FIPTIMEOUT neutron lbaas-pool-create --name "${RPRE}Pool_0" --protocol $PROTO --lb-algorithm=ROUND_ROBIN $SESSPERS --loadbalancer ${LBAASS[0]} # --wait
   handleLBErr $? "PoolCreate"
   if test $RC != 0; then let LBERRORS+=1; return $RC; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3951,7 +3951,7 @@ else # test "$1" = "DEPLOY"; then
  if test -n "$RESHUFFLE"; then let MAXCYC+=$((2*$NFACT*$NOVMS)); fi
  if test -n "$FULLCONN"; then let MAXCYC+=$(($NOVMS*$NOVMS/10)); fi
  if test -n "$IPERF"; then let MAXCYC+=$((6*$NONETS)); fi
- if test -n "$LOADBALANCER"; then let MAXCYC+=$((32+4*$NOVMS)); fi
+ if test -n "$LOADBALANCER"; then let MAXCYC+=$((36+4*$NOVMS+$WAITLB)); fi
  # FIXME: We could check THISRUNSUCCESS instead?
  if test $VMERRORS = 0 -a $WAITERRORS = 0 -a $THISRUNTIME -gt $MAXCYC; then
     sendalarm 1 "SLOW PERFORMANCE" "Cycle time: $THISRUNTIME (max $MAXCYC)" $MAXCYC

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2314,7 +2314,7 @@ testLBs()
   done
   echo
   if test $LBERR != 0; then
-    sendalarm 2 "Errors connecting to LB $LBIP port 80" "$LBERR" 4
+    sendalarm 2 "Errors connecting to LB $LBIP port 80: $ERRREASON" "$LBERR" 4
     if test -n "$EXITERR"; then exit 3; fi
   fi
   LBERRORS+=$LBERR

--- a/run_pluspco.sh
+++ b/run_pluspco.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# Specify image names, JumpHost ideally has sfw2-snat
+# Options for the images: my openSUSE 15.2 (linux), Ubuntu 20.04 (ubuntu),
+#  openSUSE Leap 15.2 (opensuse), CentOS 8 (centos)
+# You can freely mix ...
+export JHIMG="Ubuntu 20.04"
+#export JHIMG="openSUSE 15.3"
+#export ADDJHVOLSIZE=2
+export IMG="Ubuntu 20.04"
+#export IMG="openSUSE 15.3"
+#export IMG="CentOS 8"
+# DEFLTUSER from image_original_user property
+#export DEFLTUSER=opensuse
+#export DEFLTUSER=ubuntu
+#export JHDEFLTUSER=ubuntu
+# You can use a filter when listing images (because your catalog is huge)
+#export JHIMGFILT="--property-filter os_version=openSUSE-15.0"
+#export IMGFILT="--property-filter os_version=openSUSE-15.0"
+# ECP flavors
+#if test $OS_REGION_NAME == Kna1; then
+export JHFLAVOR=1C-1GB-20GB
+export FLAVOR=1C-0.5GB-20GB
+#else
+#export JHFLAVOR=1C-1GB-10GB
+#export FLAVOR=1C-1GB-10GB
+#fi
+# EMail notifications sender address
+export FROM=kurt@garloff.de
+# Only use one AZ
+export AZS="az1"
+# Upload (compressed) logfiles and stats to container
+#export SWIFTCONTAINER=OS-HM-Logfiles
+
+# Assume OS_ parameters have already been sourced from some .openrc file
+# export OS_CLOUD=gx-scs-healthmgr
+
+export EMAIL_PARAM=${EMAIL_PARAM:-"scs@garloff.de"}
+
+# Notifications & Alarms (pass as list, arrays can't be exported)
+ALARM_EMAIL_ADDRESSES="scs@garloff.de"
+NOTE_EMAIL_ADDRESSES="scs@garloff.de"
+#ALARM_EMAIL_ADDRESSES="scs@garloff.de scs-monitoring@plusserver.com"
+#NOTE_EMAIL_ADDRESSES="scs@garloff.de"
+export ALARM_EMAIL_ADDRESSES NOTE_EMAIL_ADDRESSES
+
+# Terminate early on auth error
+openstack server list >/dev/null
+
+# Find Floating IPs
+FIPLIST=""
+FIPS=$(openstack floating ip list -f value -c ID)
+for fip in $FIPS; do
+	FIP=$(openstack floating ip show $fip | grep -o "APIMonitor_[0-9]*")
+	if test -n "$FIP"; then FIPLIST="${FIPLIST}${FIP}_
+"; fi
+done
+# Cleanup previous interrupted runs
+SERVERS=$(openstack server  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+VOLUMES=$(openstack volume  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+NETWORK=$(openstack network list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+LOADBAL=$(openstack loadbalancer list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+ROUTERS=$(openstack router  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+SECGRPS=$(openstack security group list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+echo CLEANUP: FIPs $FIPLIST Servers $SERVERS Volumes $VOLUMES Networks $NETWORK LoadBalancers $LOADBAL Routers $ROUTERS SecGrps $SECGRPS
+for ENV in $FIPLIST; do
+  echo "******************************"
+  echo "CLEAN $ENV"
+  bash ./api_monitor.sh -o -T -q -c CLEANUP $ENV
+  echo "******************************"
+done
+TOCLEAN=$(echo "$SERVERS
+$VOLUMES
+$NETWORK
+$LOADBAL
+$ROUTERS
+$SECGRPS
+" | grep -v '^$' | sort -u)
+for ENV in $TOCLEAN; do
+  echo "******************************"
+  echo "CLEAN $ENV"
+  #bash ./api_monitor.sh -o -T -q -c CLEANUP $ENV
+  bash ./api_monitor.sh -o -q -c CLEANUP $ENV
+  echo "******************************"
+done
+
+#bash ./api_monitor.sh -c -x -d -n 8 -l last.log -e $EMAIL_PARAM -S -i 9
+#exec api_monitor.sh -o -C -D -N 2 -n 8 -s -e sender@domain.org "$@"
+#exec ./api_monitor.sh -O -C -D -N 2 -n 8 -s -L -b -B -a 2 -t -T -R "$@"
+exec ./api_monitor.sh -O -C -D -N 2 -n 8 -s -LL -b -B -a 2 -t -T -R -S plus-pco "$@"
+


### PR DESCRIPTION
By arbitrarily killing backend processes (that serve the http port),
we check whether the LB's health monitor does detect this, goes
into DEGRADED mode and only circles through the ONLINE members.

We now support testing either TCP `-LL` or HTTP `-L` loadbalancers.
Version 1.79.

Signed-off-by: Kurt Garloff <kurt@garloff.de>