### PR TITLE
Allow NOT supplying nameservers to subnets.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -151,10 +151,12 @@ NOVMS=12
 NONETS=$NOAZS
 MANUALPORTSETUP=1
 ROUTERITER=1
+if test -z "$DEFAULTNAMESERVER"; then
 if [[ $OS_AUTH_URL == *otc*t-systems.com* ]]; then
   NAMESERVER=${NAMESERVER:-100.125.4.25}
 fi
 if test -z "$NAMESERVER"; then NAMESERVER=8.8.8.8; fi
+fi
 
 MAXITER=-9999
 
@@ -299,7 +301,7 @@ usage()
   echo "You can override defaults by exporting the environment variables AZS, VAZS, RPRE,"
   echo " PINGTARGET, PINGTARGET2, GRAFANANM, [JH]IMG, [JH]IMGFILT, [JH]FLAVOR, [JH]DEFLTUSER,"
   echo " ADDJHVOLSIZE, ADDVMVOLSIZE, SUCCWAIT, ALARMPRE, FROM, ALARM_/NOTE_EMAIL_ADDRESSES,"
-  echo " NAMESERVER, SWIFTCONTAINER."
+  echo " NAMESERVER/DEFAULTNAMESERVER, SWIFTCONTAINER."
   echo "Typically, you should configure [JH]IMG, [JH]FLAVOR, [JH]DEFLTUSER."
   exit 0
 }

--- a/run_wave.sh
+++ b/run_wave.sh
@@ -31,6 +31,7 @@ export FROM=kurt@garloff.de
 #export AZS="az1"
 # Upload (compressed) logfiles and stats to container
 #export SWIFTCONTAINER=OS-HM-Logfiles
+export DEFAULTNAMESERVER="true"
 
 # Assume OS_ parameters have already been sourced from some .openrc file
 # export OS_CLOUD=gx-scs-healthmgr


### PR DESCRIPTION
This results in defaults from your cloud being used, which often is a good choice. Use this for the wavestack cloud.

Signed-off-by: Kurt Garloff <kurt@garloff.de>