### PR TITLE
Fix wait time reporting in waitResources.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1259,7 +1259,7 @@ waitResources()
         TM=$(math "%i" "$TM-${SLIST[$i]}")
         eval ${CSTAT}+="($TM)"
         if test $STE -ge 2; then GRC=0; else GRC=$STE; fi
-        log_grafana "wait$RNM" "$COMP1" "$TIM" "$GRC"
+        log_grafana "wait$RNM" "$COMP1" "$TM" "$GRC"
         unset SLIST[$i]
       fi
     done


### PR DESCRIPTION
Only the resources waited for in waitlistResources would be properly reported to telegraf/influx/grafana, there was a typo in the ones waited for in waitResources. This cause waitJHPORT not to be visible in grafana. Fixed.

Signed-off-by: Kurt Garloff <kurt@garloff.de>