### PR TITLE
Assign Floating IPs earlier after JHVM creation.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3835,20 +3835,20 @@ else # test "$1" = "DEPLOY"; then
            waitJHVols # TODO: Error handling
            if createJHVMs; then
             let ROUNDVMS=$NOAZS
-            waitVols  # TODO: Error handling
-            if createVMs; then
-             let ROUNDVMS+=$NOVMS
-             waitJHVMs
-             RC=$?
-             if test $RC != 0; then
+            if createFIPs; then
+             waitVols  # TODO: Error handling
+             if createVMs; then
+              let ROUNDVMS+=$NOVMS
+              waitJHVMs
+              RC=$?
+              if test $RC != 0; then
                #sendalarm $RC "Timeout waiting for JHVM ${RRLIST[*]}" "$WAITERRSTR" $((4*$MAXWAIT))
                # FIXME: Shouldn't we count errors and abort here? Without JumpHosts, the rest is hopeless ...
                if test $RC -gt $NOAZS; then let VMERRORS+=$NOAZS; else let VMERRORS+=$RC; fi
-             else
-              # loadbalancer
-              waitLBs
-              LBERRORS=$?
-              if createFIPs; then
+              else
+               # loadbalancer
+               waitLBs
+               LBERRORS=$?
                # No error handling here (but alarms are generated)
                waitVMs
                # Errors will be counted later again
@@ -3942,9 +3942,9 @@ else # test "$1" = "DEPLOY"; then
                 if test -n "$LOADBALANCER" -a "$LBACTIVE" = "1"; then cleanLBs; fi
                fi
                # TODO: Detach and delete disks again
-              fi; deleteFIPs
-             fi; #JH wait successful
-            fi; deleteVMs
+              fi; #JH wait successful
+             fi; deleteVMs
+            fi; deleteFIPs
            fi; deleteJHVMs
           fi; deleteKeypairs
          fi; waitdelVMs; deleteVols


### PR DESCRIPTION
This is an attempt to work around a situation where the FIP assignment that happens during the JumpHost VM booting and downloading packages (triggered by cloud-init userdata) does disrupt communication for a while.

Signed-off-by: Kurt Garloff <kurt@garloff.de>