### PR TITLE
Only wait for JHPORT b/f assigning FIP if needed.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -301,7 +301,7 @@ usage()
   echo "You can override defaults by exporting the environment variables AZS, VAZS, RPRE,"
   echo " PINGTARGET, PINGTARGET2, GRAFANANM, [JH]IMG, [JH]IMGFILT, [JH]FLAVOR, [JH]DEFLTUSER,"
   echo " ADDJHVOLSIZE, ADDVMVOLSIZE, SUCCWAIT, ALARMPRE, FROM, ALARM_/NOTE_EMAIL_ADDRESSES,"
-  echo " NAMESERVER/DEFAULTNAMESERVER, SWIFTCONTAINER."
+  echo " NAMESERVER/DEFAULTNAMESERVER, SWIFTCONTAINER, FIPWAITPORTDEVOWNER."
   echo "Typically, you should configure [JH]IMG, [JH]FLAVOR, [JH]DEFLTUSER."
   exit 0
 }
@@ -1836,11 +1836,12 @@ createFIPs()
   # Not needed on OTC, but for most other OpenStack clouds:
   # Connect Router to external network gateway
   ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET
-  # Actually this fails if the port is not assigned to a VM yet
-  #  -- we can not associate a FIP to a port w/o dev owner
-  # So wait for JHPORTS having a device owner
-  #echo "Wait for JHPorts: "
-  waitResources NETSTATS JHPORT JPORTSTAT JVMSTIME "NONNULL" "NONONO" "device_owner" $NETTIMEOUT neutron port-show
+  if test -n "$FIPWAITPORTDEVOWNER"
+    # Actually this fails if the port is not assigned to a VM yet
+    #  -- we can not associate a FIP to a port w/o dev owner on some clouds
+    # So wait for JHPORTS having a device owner
+    waitResources NETSTATS JHPORT JPORTSTAT JVMSTIME "NONNULL" "NONONO" "device_owner" $NETTIMEOUT neutron port-show
+  fi
   # Now FIP creation is safe
   createResources $NOAZS FIPSTATS FIP JHPORT NONE "" id $FIPTIMEOUT neutron floatingip-create --port-id \$VAL --description ${RPRE}JH\$no $EXTNET
   if test $? != 0 -o -n "$INJECTFIPERR"; then return 1; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1837,7 +1837,7 @@ createFIPs()
   # Not needed on OTC, but for most other OpenStack clouds:
   # Connect Router to external network gateway
   ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET
-  if test -n "$FIPWAITPORTDEVOWNER"
+  if test -n "$FIPWAITPORTDEVOWNER"; then
     # Actually this fails if the port is not assigned to a VM yet
     #  -- we can not associate a FIP to a port w/o dev owner on some clouds
     # So wait for JHPORTS having a device owner

--- a/run_otc.sh
+++ b/run_otc.sh
@@ -34,9 +34,10 @@ export AZS="eu-de-01 eu-de-03"
 export VAZS="eu-de-01 eu-de-03"
 # Upload (compressed) logfiles and stats to container
 export SWIFTCONTAINER=OS-HM-Logfiles
-# NAMESERVER
+# OTC Settings: NAMESERVER ...
 export NAMESERVER=100.125.4.25
-
+export DEFAULTNAMESERVER=1
+export FIPWAITPORTDEVOWNER=1
 export OLD_OCTAVIA=1
 
 # Assume OS_ parameters have already been sourced from some .openrc file


### PR DESCRIPTION
This was required on OTC, and we can still force the waiting by setting the FIPWAITPORTDEVOWNER environment.

Signed-off-by: Kurt Garloff <kurt@garloff.de>