### PR TITLE
Use small openSUSE image, using SCS-1L:1:5 flavor.

### DIFF
--- a/run_pluspco.sh
+++ b/run_pluspco.sh
@@ -4,11 +4,11 @@
 # Options for the images: my openSUSE 15.2 (linux), Ubuntu 20.04 (ubuntu),
 #  openSUSE Leap 15.2 (opensuse), CentOS 8 (centos)
 # You can freely mix ...
-export JHIMG="Ubuntu 20.04"
-#export JHIMG="openSUSE 15.3"
+#export JHIMG="Ubuntu 20.04"
+export JHIMG="openSUSE 15.4"
 #export ADDJHVOLSIZE=2
-export IMG="Ubuntu 20.04"
-#export IMG="openSUSE 15.3"
+#export IMG="Ubuntu 20.04"
+export IMG="openSUSE 15.4"
 #export IMG="CentOS 8"
 # DEFLTUSER from image_original_user property
 #export DEFLTUSER=opensuse
@@ -19,8 +19,9 @@ export IMG="Ubuntu 20.04"
 #export IMGFILT="--property-filter os_version=openSUSE-15.0"
 # ECP flavors
 #if test $OS_REGION_NAME == Kna1; then
-export JHFLAVOR=1C-1GB-20GB
-export FLAVOR=1C-0.5GB-20GB
+export JHFLAVOR=SCS-1L:1:5
+#export JHFLAVOR=SCS-1V:1:10
+export FLAVOR=SCS-1L:1:5
 #else
 #export JHFLAVOR=1C-1GB-10GB
 #export FLAVOR=1C-1GB-10GB


### PR DESCRIPTION
My own 4GiB openSUSE image nicely fits the smallest standardized SCS flavor: SCS-1L:1:5. This reduces the resource consumption for the openStack health monitor in the PCO environment.

Link to the image:
https://kfg.images.obs-website.eu-de.otc.t-systems.com/

Signed-off-by: Kurt Garloff <kurt@garloff.de>