### PR TITLE
Fix/assign extnet earlier

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -98,7 +98,7 @@
 # ./api_monitor.sh -n 8 -d -P -s -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMon-Notes -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMonitor -i 100
 # (SMN is OTC specific notification service that supports sending SMS.)
 
-VERSION=1.84
+VERSION=1.85
 
 # debugging
 if test "$1" == "--debug"; then set -x; shift; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1508,14 +1508,7 @@ showResources()
 createRouters()
 {
   if test -z "$ROUTERS"; then
-    createResources 1 NETSTATS ROUTER NONE NONE "" id $FIPTIMEOUT neutron router-create ${RPRE}Router || return
-    # Need to attach external net gateway
-    ostackcmd_tm NETSTATS $NETTIMEOUT neutron net-external-list || return
-    #EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\2/')
-    EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\1/')
-    # Not needed on OTC, but for most other OpenStack clouds:
-    # Connect Router to external network gateway
-    ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET
+    createResources 1 NETSTATS ROUTER NONE NONE "" id $FIPTIMEOUT neutron router-create ${RPRE}Router
   fi
 }
 
@@ -1838,6 +1831,12 @@ createFIPs()
 {
   local FLOAT RESP
   #createResources $NOAZS NETSTATS JHPORT NONE NONE "" id $NETTIMEOUT neutron port-create --security-group ${SGROUPS[0]} --name "${RPRE}Port_JH\${no}" ${JHNETS[0]} || return
+  ostackcmd_tm NETSTATS $NETTIMEOUT neutron net-external-list || return 1
+  #EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\2/')
+  EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\1/')
+  # Not needed on OTC, but for most other OpenStack clouds:
+  # Connect Router to external network gateway
+  ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET
   # Actually this fails if the port is not assigned to a VM yet
   #  -- we can not associate a FIP to a port w/o dev owner
   # So wait for JHPORTS having a device owner

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1510,12 +1510,13 @@ createRouters()
   if test -z "$ROUTERS"; then
     createResources 1 NETSTATS ROUTER NONE NONE "" id $FIPTIMEOUT neutron router-create ${RPRE}Router || return
     # Need to attach external net gateway
-    ostackcmd_tm NETSTATS $NETTIMEOUT neutron net-external-list || return
+    ostackcmd_tm NETSTATS $NETTIMEOUT neutron net-external-list
+    if test $? != 0; then deleteRouters; return 1; fi
     #EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\2/')
     EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\1/')
     # Not needed on OTC, but for most other OpenStack clouds:
     # Connect Router to external network gateway
-    ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET
+    ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET || true
   fi
 }
 


### PR DESCRIPTION
Should be merged after #106.

This one may resolve the observed trouble on wave-scs.
Currently, we do the `openstack server create JH` call immediately before assigning the FIP to the JH port; the FIP creation and assignment is preceeded by the `external-gateway-set` call for the router to ensure that the FIP can be assigned which is preceeded by a `openstack network list --external`.
If for whatever reason the `network list` or `router set --external-gateway` calls are very slow, the VM may have started to boot already before the gateway is set on the router. In the worst case, this could lead to the VM not being able to talk to the outside world via SNAT (nor via the FIP) in its early boot stage.

When we later connect to the VM, we of course have the external-gateway configured and the FIP assigned (we connect via the FIP). Nevertheless, occasioanlly, the external gateway seems to be delayed in being effective by a minute or two in such cases. This should not happen and looks like a bug to me. However, it's relatively harmless, as setting the external gateway to a router (just) after VM creation is unusual.

This fix moves the `router set --external-gateway` to happen immediately after the router creation. Thus well ahead of any VM creation. If the effectiveness of the router gateway setting is delayed enough, we might still see the bug, but I'm optimistic that this will not happen.
