### PR TITLE
Medium old OSC reports Networks in a diff format.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2062,7 +2062,7 @@ collectPorts()
   # FIXME: We could use the new reporting: -c ID -c "Fixed IP Addressess" -c "Device ID"
   # (but that does not help either to recover the lost device_id fields)
   ostackcmd_tm NETSTATS $NETTIMEOUT neutron port-list -c id -c fixed_ips -f json
-  #echo -e "#DEBUG: cP VMs ${VMS[*]}\n\'$OSTACKRESP\'"
+  #echo -e "#DEBUG: cP VMs ${VMS[*]}\n\'$OSTACKRESP\'\n\'$IPRESP\'"
   #echo "#DEBUG: cP VMs ${VMS[*]}"
   if test -n "$SECONDNET" -a -z "$SECONDPORTS"; then COLLSECOND=1; else unset COLLSECOND; fi
   for vm in $(seq 0 $(($NOVMS-1))); do

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2071,8 +2071,10 @@ collectPorts()
     # FIXME: In theory, we need to filter for the correct subnet as well
     # (In practice: An IP address conflict is very unlikely ...)
     ipaddr=$(echo "$IPRESP" | jq ".[] | select(.ID == \"$vmid\") | .Networks" | grep '10\.250\.' | head -n1 | sed 's/^[^"]*"\([0-9\.]*\)".*$/\1/')
+    ipaddr="${ipaddr##*=}"; ipaddr="${ipaddr%\"}"
     if test -n "$COLLSECOND"; then
       ipaddr2=$(echo "$IPRESP" | jq ".[] | select(.ID == \"$vmid\") | .Networks" | grep '10\.251\.' | head -n1 | sed 's/^[^"]*"\([0-9\.]*\)".*$/\1/')
+      ipaddr2="${ipaddr2##*=}"; ipaddr2="${ipaddr2%\"}"
     fi
     port=$(echo "$OSTACKRESP" | jq ".[] | select(.\"Fixed IP Addresses\"[].ip_address == \"$ipaddr\").ID" | tr -d '"')
     #echo -e "#DEBUG: Search Port for VM $vmid with IP $ipaddr => port $port"


### PR DESCRIPTION
So OSC-5.5.0 reports (`openstack server list -f json`):
```
[
  {
    "ID": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
    "Name": "HealthMon-Host",
    "Networks": {
      "kd500924-SCS-healthmonitor-network": [
        "192.168.0.17",
        "78.138.66.252"
      ]
    }
  }
]
```
whereas older version OSC-5.3.1 reports
```
[
  {
    "ID": "XXXXXXXXXXXXXXXXXXXXXXXXX",
    "Name": "testkg2",
    "Networks": "testkg2=192.168.33.95, 31.172.117.55",
  }
]
```
Adjust IP parser to handle both ...

Signed-off-by: Kurt Garloff <kurt@garloff.de>