### PR TITLE
When outputting codes for cols, we need echo -e.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3809,7 +3809,7 @@ elif test "$1" = "CONNTEST"; then
      # Error counting done by fullconntest already
      errwait $ERRWAIT
    elif test $FPRETRY != 0; then
-     echo "${YELLOW}Warning:${NORM} Needed $FPRETRY ping retries"
+     echo -e "${YELLOW}Warning:${NORM} Needed $FPRETRY ping retries"
    fi
    if test -n "$RESHUFFLE"; then
      reShuffle
@@ -3958,7 +3958,7 @@ else # test "$1" = "DEPLOY"; then
                     sendalarm 2 "Connectivity errors" "$FPERR + $FPRETRY\n$ERR" 5
                     errwait $ERRWAIT
                   elif test $FPRETRY != 0; then
-                   echo "${YELLOW}Warning:${NORM} Needed $FPRETRY ping retries"
+                   echo -e "${YELLOW}Warning:${NORM} Needed $FPRETRY ping retries"
                   fi
                   if test -n "$SECONDNET" -a -n "$RESHUFFLE"; then
                     reShuffle


### PR DESCRIPTION
Cosmetic. This was missing from ed808bba.

Signed-off-by: Kurt Garloff <kurt@garloff.de>