### PR TITLE
Feat/python stats

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -98,7 +98,7 @@
 # ./api_monitor.sh -n 8 -d -P -s -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMon-Notes -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMonitor -i 100
 # (SMN is OTC specific notification service that supports sending SMS.)
 
-VERSION=1.85
+VERSION=1.86
 
 # debugging
 if test "$1" == "--debug"; then set -x; shift; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3125,7 +3125,7 @@ EOT
 
 # [-m] STATLIST [DIGITS [NAME [PCTILE]]]
 # m for machine readable
-stats()
+stats_old()
 {
   local NM NO VAL LIST DIG OLDIFS SLIST MIN MAX MID MED NFQ NFQL NFQR NFQF NFP AVGC AVG
   if test "$1" = "-m"; then MACHINE=1; shift; else unset MACHINE; fi
@@ -3179,6 +3179,19 @@ stats()
       echo "$NAME: Num $NO Min $MIN $PCT% $NFP Med $MED Avg $AVG Max $MAX" | tee -a $LOGFILE
     fi
   fi
+}
+
+# [-m] STATLIST [DIGITS [NAME [PCTILE]]]
+# m for machine readable
+stats()
+{
+  if test "$1" = "-m"; then MACHINE="-m"; shift; else unset MACHINE; fi
+  if test -n "$3" -a -z "$MACHINE"; then NAME=$3; else NAME=$1; fi
+  DIG=${2:-2}
+  PCT=${4:-95}
+  echo -n "$NAME: " | tee -a $LOGFILE
+  eval LIST=( \"\${${1}[@]}\" )
+  echo "${LIST[*]}" | ./stats.py -d $DIG -p $PCT $MACHINE | tee -a $LOGFILE
 }
 
 # [-m] for machine readable

--- a/stats.py
+++ b/stats.py
@@ -1,0 +1,69 @@
+#!/usr/bin/python3
+#
+# Calculate stats over array of numbers (read from stdin)
+# Outpus Num Min Med Avg Pct% Max
+# The percentile can be specified on the command line (-p)
+# The number of digits as well (-d)
+#
+# (c) Kurt Garloff <kurt@garloff.de>
+# SPDX-License-Identifier: CC-BY-SA-4.0
+
+import sys, os
+
+prec = 1e-5
+
+def stats(arr, pct=95, digi=2, machine=False):
+    aln = len(arr)
+    arr.sort()
+    middle = int(aln/2)
+    if aln%2:
+        med = arr[middle]
+    else:
+        med = (arr[middle-1]+arr[middle])/2.0
+    avg = sum(arr)/aln
+    pctpos = (aln-1)*pct/100
+    pctposi = int(pctpos+prec)
+    wgt = pctpos - pctposi
+    if abs(wgt) < prec:
+        pctl = arr[pctposi]
+    else:
+        pctl = arr[pctposi+1]*wgt + arr[pctposi]*(1-wgt)
+    fmt = ".%if" % digi
+    if abs(pct - int(pct)) == 0:
+        pctfmt = "%i%%" % pct
+    else:
+        pctfmt = "%.2f%%" % pct
+    if machine:
+        fstr = "{}|{:%s}|{:%s}|{:%s}|{:%s}|{:%s}" % (fmt, fmt, fmt, fmt, fmt)
+    else:    
+        if pct > 50:
+            fstr = "Num {0} Min {1:%s} Med {2:%s} Avg {3:%s} %s {4:%s} Max {5:%s}" % (fmt, fmt, fmt, pctfmt, fmt, fmt)
+        else:
+            fstr = "Num {0} Min {1:%s} %s {4:%s} Med {2:%s} Avg {3:%s} Max {5:%s}" % (fmt, pctfmt, fmt, fmt, fmt, fmt)
+    #print(fstr)
+    print(fstr.format(aln, arr[0], med, avg, pctl, arr[aln-1]))
+
+def main(argv):
+    pct = 95
+    dig = 2
+    machine = False
+    optidx = 0
+    while optidx < len(argv):
+        if argv[optidx] == '-p':
+            optidx += 1
+            pct = float(argv[optidx])
+        elif argv[optidx] == '-d':
+            optidx += 1
+            dig = int(argv[optidx])
+        elif argv[optidx] == '-m':
+            machine = True
+        else:
+            print("Error: Unknown option \"%s\". Usage stats.py [-p pct] [-d dig] [-m] < data" % argv[optidx])
+            sys.exit(1)
+        optidx += 1
+
+    arr = list(map(lambda x: float(x), sys.stdin.read().rstrip("\n").split(" ")))
+    stats(arr, pct, dig, machine)
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
When api_monitor.sh runs with many iterations, we have lots of timing info stored -- calculating medians, percentiles, ... in bash starts to take a long time (10s of seconds per iteration).
Obviously bash is not the most suitable language for this.
As we require python3 anyway as math helper, let's rather create a small script that does it all. 100x faster.