### PR TITLE
If there are multiple external nets, use the first.

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1515,7 +1515,7 @@ createRouters()
     ostackcmd_tm NETSTATS $NETTIMEOUT neutron net-external-list
     if test $? != 0; then deleteRouters; return 1; fi
     #EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\2/')
-    EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\1/')
+    EXTNET=$(echo "$OSTACKRESP" | grep '^| [0-9a-f-]* |' | head -n1 | sed 's/^| \([0-9a-f-]*\) | \([^ ]*\).*$/\1/')
     # Not needed on OTC, but for most other OpenStack clouds:
     # Connect Router to external network gateway
     ostackcmd_tm NETSTATS $NETTIMEOUT neutron router-gateway-set ${ROUTERS[0]} $EXTNET || true


### PR DESCRIPTION
Previously, we tried to use several, confusing numerous followup commands.

Signed-off-by: Kurt Garloff <kurt@garloff.de>