### PR TITLE
Add user systemd unit and tmux start scripts.

### DIFF
--- a/startup/README.md
+++ b/startup/README.md
@@ -4,7 +4,8 @@
 * Checkout a copy of openstack health monitor
   `git clone https://github.com/SovereignCloudStack/openstack-health-monitor`
 * Install the python3-openstackclient tools
-* Configure your cloud access in ~/.config/openstack/clouds.yaml and secure.yaml
+* Configure your cloud access in `~/.config/openstack/clouds.yaml` and
+  `secure.yaml`
 * Ensure your openstack client tools work:
   ```
   export OS_CLOUD=YOURCLOUD
@@ -23,18 +24,28 @@
 * Create a file `run_in_loop.sh` which runs `run_YOURCLOUD.sh` in a loop:
   ```
   #!/bin/bash
-  while true; do ./run_YOURCLOUD.sh -s -i 200; echo -n "Hit ^C to abort ..."; sleep 15; echo; done
+  rm stop-os-hm 2>/dev/null
+  while true; do
+    ./run_YOURCLOUD.sh -s -i 200
+    if test -e stop-os-hm; then break; fi
+    echo -n "Hit ^C to abort ..."
+    sleep 15; echo
+  done
   ```
-  This will run 200 iterations in `api_monitor` and then restart.
+  This will run 200 iterations in `api_monitor.sh` and then restart.
 
 ## System startup
-* Edit the tmux startup script `run-apimon-in-tmux.sh` to set `OS_CLOUD` correctly
-  for your cloud.
-* Copy `apimon.service` to `~/.config/systemd/user`. (You might need to create that
-  directory first.)
-* Test that you can start the service by calling `systemctl --user start apimon`
-* This should create a tmux session in which the OpenStack Health Momitor is running.
-  Attach to the tmux session `tmux attach -t oshealthmon`.
+* Edit the tmux startup script `run-apimon-in-tmux.sh` to set `OS_CLOUD`
+  correctly for your cloud.
+* If you are not using ~/openstack-health-monitor for the checked out git
+  tree, you need to adjust the scripts and the systemd unit file here
+  accordingly.
+* Copy `apimon.service` to `~/.config/systemd/user`. (You might need to
+  create that directory first.)
+* Test that you can start the service by calling 
+  `systemctl --user start apimon`
+* This should create a tmux session in which the OpenStack Health Momitor
+  is running.  Attach to the tmux session `tmux attach -t oshealthmon`.
 * You can stop the service by hitting ^C (Control-c), possibly several times.
 * Now enable the service: `systemctl --user enable apimon`
 * And tell systemd that it should create a user session on startup:

--- a/startup/README.md
+++ b/startup/README.md
@@ -1,0 +1,41 @@
+# How to enable autostart for OpenStack Health Monitor (aka apimon).
+
+## Preparation
+* Checkout a copy of openstack health monitor
+  `git clone https://github.com/SovereignCloudStack/openstack-health-monitor`
+* Install the python3-openstackclient tools
+* Configure your cloud access in ~/.config/openstack/clouds.yaml and secure.yaml
+* Ensure your openstack client tools work:
+  ```
+  export OS_CLOUD=YOURCLOUD
+  openstack image list
+  ```
+* Ensure that apimon works
+  `./api_monitor.sh -O -C -D -N 2 -n 8 -L -b -B -T -i 1`
+  This will run one iteration of the monitor, creating 10 VMs with default
+  flavors (SCS-1V-2 and SCS-1L-1) and images (Ubuntu 22.04).
+  This will take 5 to 10 minutes.
+  The option `-L` enables the loadbalancer testing; you might have to remove
+  it if your cloud does not support octavia/lbaasv2.
+  See `./api_monitor.sh --help` for an overview over options.
+* Create a run script by copying e.g. `run_wave.sh` and editing it according
+  to your needs.
+* Create a file `run_in_loop.sh` which runs `run_YOURCLOUD.sh` in a loop:
+  ```
+  #!/bin/bash
+  while true; do ./run_YOURCLOUD.sh -s -i 200; echo -n "Hit ^C to abort ..."; sleep 15; echo; done
+  ```
+  This will run 200 iterations in `api_monitor` and then restart.
+
+## System startup
+* Edit the tmux startup script `run-apimon-in-tmux.sh` to set `OS_CLOUD` correctly
+  for your cloud.
+* Copy `apimon.service` to `~/.config/systemd/user`. (You might need to create that
+  directory first.)
+* Test that you can start the service by calling `systemctl --user start apimon`
+* This should create a tmux session in which the OpenStack Health Momitor is running.
+  Attach to the tmux session `tmux attach -t oshealthmon`.
+* You can stop the service by hitting ^C (Control-c), possibly several times.
+* Now enable the service: `systemctl --user enable apimon`
+* And tell systemd that it should create a user session on startup:
+  `sudo loginctl enable-linger $USER`

--- a/startup/apimon.service
+++ b/startup/apimon.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Start the OpenStack Health Monitor
+#After=network.target systemd-user-sessions.service
+
+[Service]
+#User=%i
+ExecStart=%h/openstack-health-monitor/startup/run-apimon-in-tmux.sh
+ExecStop=%h/openstack-health-monitor/startup/kill-apimon-in-tmux.sh
+Type=forking
+#Slice=session.slice
+#Type=oneshot
+#RemainAfterExit=yes
+
+[Install]
+WantedBy=default.target
+Alias=os-health-mon.service

--- a/startup/kill-apimon-in-tmux.sh
+++ b/startup/kill-apimon-in-tmux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+session="oshealthmon"
+tmux select-window -t $session:0
+tmux send-keys C-c
+sleep 30
+killall run_in_loop.sh
+sleep 5
+tmux kill-session -t $session

--- a/startup/kill-apimon-in-tmux.sh
+++ b/startup/kill-apimon-in-tmux.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
+echo "oshealthmon session going down" | wall
 session="oshealthmon"
 tmux select-window -t $session:0
+# Tell master loop to exit
+cd ~/openstack-health-monitor
+touch stop-os-hm
+# Send two ^C to the api_monitor for immediate cleanup
 tmux send-keys C-c
-sleep 30
-killall run_in_loop.sh
-sleep 5
+sleep 1
+tmux send-keys C-c
+sync
+# Give it max 4min to cleanup and exit, so we don't delay a reboot by more than 5 mins
+MAXW=240
+let -i ctr=0
+while test $ctr -lt $MAXW; do
+	if test -z "$(ps a | grep run_in_loop.sh | grep -v grep)"; then break; fi
+	sleep 1
+	let ctr+=1
+done
+if test $ctr = $MAXW; then killall run_in_loop.sh; sleep 1; fi
 tmux kill-session -t $session

--- a/startup/run-apimon-in-tmux.sh
+++ b/startup/run-apimon-in-tmux.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+session="oshealthmon"
+export OS_CLOUD=wave-hm
+tmux start-server
+tmux new-session -d -s $session -n apimon
+tmux new-window -t $session:1 -n shell
+tmux send-keys "cd ~/openstack-health-monitor; export OS_CLOUD=$OS_CLOUD" C-m
+tmux select-window -t $session:0
+tmux send-keys "cd ~/openstack-health-monitor; export OS_CLOUD=$OS_CLOUD" C-m
+tmux send-keys "./run_in_loop.sh" C-m
+


### PR DESCRIPTION
Even with some docu.

This one was a bit of work:
* Create a tmux script that starts a tmux session and pushed some commands into it to start run_in_loop.sh which calls run_YOURCLOUD.sh which calls api_monitor.sh
* There's also a kill script that sends ^C, so cleanup can start happening.
* There is a systemd file, meant to be installed into the `--user` systemd logic
* And documentation that explains how to use it, including the important
  `sudo loginctl enable-linger $USER` command which I learned doing this.