### PR TITLE
Feat/avoid failedvm iperf

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -1631,7 +1631,7 @@ $OSTACKRESP"
   # Change in 1.74: Just generate an alarm here unless $1 == ""
   # Before, we left it to the caller
   if test -n "$WAITERRPREFIX"; then
-    sendalarm $RETV "Error waiting for $WAITERRPREFIX" "$WAITERRSTR"
+    sendalarm $RETV "Error waiting for $WAITERRPREFIX" "$WAITERRSTR" 0
   fi
   return $RETV
 }

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2771,7 +2771,7 @@ nameVols()
     nm=$(echo "$line" | cut -d "," -f 3)
     att=$(echo "$line" | cut -d "," -f 6)
     if test -z "$att"; then continue; fi
-    NM=$(echo "$att" | sed 's/^Attached to \(APIMonitor_[0-9]*\)_VM_\([^ ]*\) .*$/\1_RootVol_\2/')
+    NM=$(echo "$att" | sed 's/^Attached to \(APIMonitor_[0-9]*\)_\(VM\|JH\)_\([^ ]*\) .*$/\1_RootVol_\3/')
     if [[ "$NM" != APIMonitor* ]]; then
       NM=$(echo "$att" | sed "s/^Attached to \([0-9a-f\-]*\) .*\$/${RPRE}RootVol_\1/")
       if test -n "$nm"; then let natt+=1; continue; fi
@@ -2811,7 +2811,7 @@ nameUnattachedVols()
   CAND=()
   while read id nm stat sz; do
     if test -z "$sz"; then sz="$stat"; stat="$nm"; nm=""; fi
-    dbgout -n "#DEBUG: \"$id\" \"$nm\" \"$stat\" \"$z\": "
+    dbgout -n "#DEBUG: \"$id\" \"$nm\" \"$stat\" \"$sz\": "
     # Filter out vols with names or with wrong size
     if test -n "$nm"; then dbgout named; continue; fi
     #if test "$stat" == "in-use" -o "$stat" == "deleting"; then dbgout "in-use or deleting"; continue; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2771,9 +2771,11 @@ nameVols()
     nm=$(echo "$line" | cut -d "," -f 3)
     att=$(echo "$line" | cut -d "," -f 6)
     if test -z "$att"; then continue; fi
-    NM=$(echo "$att" | sed 's/^Attached to \(APIMonitor_[0-9]*\)_\(VM\|JH\)_\([^ ]*\) .*$/\1_RootVol_\3/')
+    NM=$(echo "$att" | sed 's/^Attached to \(APIMonitor_[0-9]*\)_\(VM_\|JH\)\([^ ]*\) .*$/\1_RootVol_\3/')
     if [[ "$NM" != APIMonitor* ]]; then
       NM=$(echo "$att" | sed "s/^Attached to \([0-9a-f\-]*\) .*\$/${RPRE}RootVol_\1/")
+    fi
+    if [[ "$NM" == APIMonitor* ]]; then
       if test -n "$nm"; then let natt+=1; continue; fi
     fi
     if test -n "$nm"; then continue; fi

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2804,7 +2804,7 @@ dbgout()
 }
 
 # Cleanup volumes created by nova but which did not get attached
-namelUnattachedVols()
+nameUnattachedVols()
 {
   local MISS=$1
   ostackcmd_tm_retry VOLSTATS $CINDERTIMEOUT cinder list -f value || return 1

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2460,6 +2460,7 @@ killhttp()
     #echo "DEBUG: $i: ${VMINFO[*]}"
     #testlsandping ${KEYPAIRS[1]} ${FLOATS[$JHNO]} $pno $no
     echo -n "$i: ${VMINFO[6]}[${VMINFO[2]}]}:${VMINFO[7]} (${VMINFO[5]}/${VMINFO[8]}) "
+    if test -z ${VMINFO[8]}; then echo -n "X "; continue; fi
     HOSTN=$(ssh -i $DATADIR/${KEYPAIRS[1]} -p ${VMINFO[7]} -o "PasswordAuthentication=no" -o "StrictHostKeyChecking=no" -o "ConnectTimeout=8" -o "UserKnownHostsFile=~/.ssh/known_hosts.$RPRE" $DEFLTUSER@${VMINFO[6]} "cat /var/run/www/htdocs/hostname; sudo killall python3")
     if test $? == 0; then echo -n "($HOSTN) "; else echo -n "ERROR "; fi
     #ssh -i $DATADIR/${KEYPAIRS[1]} -p ${VMINFO[7]} -o "PasswordAuthentication=no" -o "StrictHostKeyChecking=no" -o "ConnectTimeout=8" -o "UserKnownHostsFile=~/.ssh/known_hosts.$RPRE" $DEFLTUSER@${VMINFO[6]} "cat /var/run/www/htdocs/hostname; sudo killall python3"

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -99,7 +99,7 @@
 # ./api_monitor.sh -n 8 -d -P -s -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMon-Notes -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMonitor -i 100
 # (SMN is OTC specific notification service that supports sending SMS.)
 
-VERSION=1.96
+VERSION=1.97
 
 # debugging
 if test "$1" == "--debug"; then set -x; shift; fi


### PR DESCRIPTION
Failed VM creation often results in followup errors.
We don't care about the nova meta, but let's avoid the iperf tests failing.