### PR TITLE
Delete leftover ports from ovn LB healthmon

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3828,8 +3828,15 @@ cleanup()
     for sub in ${SUBNETS[*]}; do
       if ! echo "$sub" | grep '^[0-9a-f\-]\+' >/dev/null; then echo "#DEBUG: Skip port clean subnet $sub"; continue; fi
       PORTS=( $(findres "octavia-lb" neutron port-list --fixed-ip subnet=$sub) )
-      echo "Cleaning octavia ports ${PORTS[*]} in subnet $sub ..."
-      deletePorts
+      if test -n "$PORTS"; then
+	echo "Cleaning octavia (amphorae) ports ${PORTS[*]} in subnet $sub ..."
+        deletePorts
+      fi
+      PORTS=( $(findres "ovn-lb-hm-" neutron port-list --fixed-ip subnet=$sub) )
+      if test -n "$PORTS"; then
+	echo "Cleaning octavia (ovn) ports ${PORTS[*]} in subnet $sub ..."
+        deletePorts
+      fi
     done
   #fi
   SGROUPS=( $(findres "" neutron security-group-list) )

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -3830,12 +3830,12 @@ cleanup()
       PORTS=( $(findres "octavia-lb" neutron port-list --fixed-ip subnet=$sub) )
       if test -n "$PORTS"; then
 	echo "Cleaning octavia (amphorae) ports ${PORTS[*]} in subnet $sub ..."
-        deletePorts
+	deletePorts
       fi
       PORTS=( $(findres "ovn-lb-hm-" neutron port-list --fixed-ip subnet=$sub) )
       if test -n "$PORTS"; then
 	echo "Cleaning octavia (ovn) ports ${PORTS[*]} in subnet $sub ..."
-        deletePorts
+	deletePorts
       fi
     done
   #fi
@@ -3906,8 +3906,15 @@ waitnetgone()
     for sub in ${SUBNETS[*]}; do
       if ! echo "$sub" | grep '^[0-9a-f\-]\+' >/dev/null; then echo "#DEBUG: Skip port cleanup in subnet $sub"; continue; fi
       PORTS=( $(findres "octavia-lb" neutron port-list --fixed-ip subnet=$sub) )
-      echo "Cleaning octavia ports ${PORTS[*]} in subnet $sub ..."
-      deletePorts
+      if test -n "$PORTS"; then
+	echo "Cleaning octavia (amphorae) ports ${PORTS[*]} in subnet $sub ..."
+	deletePorts
+      fi
+      PORTS=( $(findres "ovn-lb-hm-" neutron port-list --fixed-ip subnet=$sub) )
+      if test -n "$PORTS"; then
+	echo "Cleaning octavia (ovn) ports ${PORTS[*]} in subnet $sub ..."
+	deletePorts
+      fi
     done
   fi
   unset IGNORE_ERRORS

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -99,7 +99,7 @@
 # ./api_monitor.sh -n 8 -d -P -s -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMon-Notes -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMonitor -i 100
 # (SMN is OTC specific notification service that supports sending SMS.)
 
-VERSION=1.101
+VERSION=1.103
 
 # debugging
 if test "$1" == "--debug"; then set -x; shift; fi


### PR DESCRIPTION
Occasionally, we may be faced with octavia ovn provider leaking ports. This prevents cleanup. So clean it up, like we do for other leftover ports from octavia.