### PR TITLE
Feat/volumetype

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,11 +108,11 @@ I would recommend a larger flavor (4GiB RAM, 20GB disk).
 
 ## Usage
 
-Use `api_monitor.sh -h` to get a list of the command line options. For reference find the output (from v1.82) here:
+Use `api_monitor.sh -h` to get a list of the command line options. For reference find the output (from v1.105) here:
 
 ```
-Running api_monitor.sh v1.104 on host kg-gxscs-hm.app-int.gx-scs.sovereignit.tech
-Using APIMonitor_1710794423_ prefix for resrcs on gxscs-hm (nova)
+Running api_monitor.sh v1.105 on host kg-gxscs-hm.app-int.gx-scs.sovereignit.tech
+Using APIMonitor_1711038748_ prefix for resrcs on gxscs-hm (nova)
 Usage: api_monitor.sh [options]
  --debug Use set -x to print every line executed
  -n N   number of VMs to create (beyond #AZ JumpHosts, def: 12)
@@ -129,6 +129,7 @@ Usage: api_monitor.sh [options]
  -S [NM] sends stats to grafana via local telegraf http_listener (def for NM=api-monitoring)
  -q     do not send any alarms
  -d     boot Directly from image (not via volume)
+ -vt TP use volumetype TP (overrides env VOLUMETYPE)
  -z SZ  boots VMs from volume of size SZ
  -P     do not create Port before VM creation
  -D     create all VMs with one API call (implies -d -P)
@@ -165,7 +166,7 @@ Or: api_monitor.sh [Options] CONNTEST XXX for full conn test for existing env XX
 You need to have the OS_ variables set to allow OpenStack CLI tools to work.
 You can override defaults by exporting the environment variables AZS, VAZS, NAZS, RPRE,
  PINGTARGET, PINGTARGET2, GRAFANANM, [JH]IMG, [JH]IMGFILT, [JH]FLAVOR, [JH]DEFLTUSER,
- ADDJHVOLSIZE, ADDVMVOLSIZE, SUCCWAIT, ALARMPRE, FROM, ALARM_/NOTE_EMAIL_ADDRESSES,
+ ADDJHVOLSIZE, ADDVMVOLSIZE, SUCCWAIT, ALARMPRE, FROM, ALARM_/NOTE_EMAIL_ADDRESSES, VOLUMETYPE,
  NAMESERVER/DEFAULTNAMESERVER, SWIFTCONTAINER, FIPWAITPORTDEVOWNER, EXTSEARCH, OS_EXTRA_PARAMS.
 Typically, you should configure OS_CLOUD, [JH]IMG, [JH]FLAVOR, [JH]DEFLTUSER.
 ```

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -4388,6 +4388,9 @@ else # test "$1" = "DEPLOY"; then
     #unset VMVOLSIZE
   fi
  fi
+ if test "$VOLUMETYPE" == "LUKS" -a -n "$NEED_BLKDEV"; then
+  echo "Warning: volume-type LUKS may be slow and nova may time out waiting for cinder vols for VM boot"
+ fi
  echo "Using images JH $JHDEFLTUSER@$JHIMG ($JHVOLSIZE GB), VM $DEFLTUSER@$IMG ($VOLSIZE GB)"
  echo "Deploying on AZs ${AZS[*]} (Volumes: ${VAZS[*]}, Networks: ${NAZS[*]})"
  if createRouters; then

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -352,6 +352,7 @@ usage()
   echo " -S [NM] sends stats to grafana via local telegraf http_listener (def for NM=api-monitoring)"
   echo " -q     do not send any alarms"
   echo " -d     boot Directly from image (not via volume)"
+  echo " -vt TP use volumetype TP (overrides env VOLUMETYPE)"
   echo " -z SZ  boots VMs from volume of size SZ"
   echo " -P     do not create Port before VM creation"
   echo " -D     create all VMs with one API call (implies -d -P)"
@@ -407,6 +408,7 @@ while test -n "$1"; do
           if test -n "$2" -a "$2" != "CLEANUP" -a "$2" != "DEPLOY" -a "${2:0:1}" != "-"; then GRAFANANM="$2"; shift; fi;;
     "-P") unset MANUALPORTSETUP;;
     "-d") BOOTFROMIMAGE=1;;
+    "-vt") VOLUMETYPE=$2; shift;;
     "-z") VMVOLSIZE=$2; shift;;
     "-D") BOOTALLATONCE=1; BOOTFROMIMAGE=1; unset MANUALPORTSETUP;;
     "-e") if test -z "$EMAIL"; then EMAIL="$2"; else EMAIL2="$2"; fi; shift;;

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2045,7 +2045,7 @@ createJHVols()
 {
   JVOLSTIME=()
   if test -n "$VOLUMETYPE"; then VOLTP="--volume-type $VOLUMETYPE"; else unset VOLTP; fi
-  createResources $NOAZS VOLSTATS JHVOLUME NONE NONE JVOLSTIME id $CINDERTIMEOUT cinder create --image-id $JHIMGID --availability-zone \${VAZS[\$VAZN]} --name ${RPRE}RootVol_JH\$no $VOLTP $JHVOLSIZE
+  createResources $NOAZS VOLSTATS JHVOLUME NONE NONE JVOLSTIME id $CINDERTIMEOUT cinder create --image-id $JHIMGID --availability-zone \${VAZS[\$VAZN]} $VOLTP --name ${RPRE}RootVol_JH\$no $JHVOLSIZE
 }
 
 # STATNM RSRCNM CSTAT STIME PROG1 PROG2 FIELD COMMAND
@@ -2066,7 +2066,7 @@ createVols()
   if test -n "$BOOTFROMIMAGE"; then return 0; fi
   VOLSTIME=()
   if test -n "$VOLUMETYPE"; then VOLTP="--volume-type $VOLUMETYPE"; else unset VOLTP; fi
-  createResources $NOVMS VOLSTATS VOLUME NONE NONE VOLSTIME id $CINDERTIMEOUT cinder create --image-id $IMGID --availability-zone \${VAZS[\$VAZN]} --name ${RPRE}RootVol_VM\$no $VOLTP $VOLSIZE
+  createResources $NOVMS VOLSTATS VOLUME NONE NONE VOLSTIME id $CINDERTIMEOUT cinder create --image-id $IMGID --availability-zone \${VAZS[\$VAZN]} $VOLTP --name ${RPRE}RootVol_VM\$no $VOLSIZE
 }
 
 # STATNM RSRCNM CSTAT STIME PROG1 PROG2 FIELD COMMAND

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -845,6 +845,7 @@ translate()
       if test "$DEFCMD" == "server" -a "$CMD" == "boot"; then
 	if [[ $ARGS = *delete_on_termination* ]]; then VOLNEEDSTAG=1; else VOLNEEDSTAG=0; fi
         #if test "$TAG" == "1"; then ARGS=$(echo "--os-compute-api-version 2.72 $ARGS" | sed "s/delete_on_termination=true/delete_on_termination=true,tag=${RPRE%_}/g"); fi
+	if [[ $ARGS = *volume_type=* ]]; then ARGS=$(echo "--os-compute-api-version 2.67 $ARGS"); fi
       fi
       #OSTACKCMD=($OPST $DEFCMD create $ARGS)
       # No token_endpoint auth for server creation (need to talk to neutron/cinder/glance as well)

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -2044,7 +2044,7 @@ delete2ndPorts()
 createJHVols()
 {
   JVOLSTIME=()
-  if test -n "$VOLUMETYPE"; then VOLTP="--volume-type=$VOLUMETYPE"; else unset VOLTP; fi
+  if test -n "$VOLUMETYPE"; then VOLTP="--volume-type $VOLUMETYPE"; else unset VOLTP; fi
   createResources $NOAZS VOLSTATS JHVOLUME NONE NONE JVOLSTIME id $CINDERTIMEOUT cinder create --image-id $JHIMGID --availability-zone \${VAZS[\$VAZN]} --name ${RPRE}RootVol_JH\$no $VOLTP $JHVOLSIZE
 }
 
@@ -2065,7 +2065,7 @@ createVols()
 {
   if test -n "$BOOTFROMIMAGE"; then return 0; fi
   VOLSTIME=()
-  if test -n "$VOLUMETYPE"; then VOLTP="--volume-type=$VOLUMETYPE"; else unset VOLTP; fi
+  if test -n "$VOLUMETYPE"; then VOLTP="--volume-type $VOLUMETYPE"; else unset VOLTP; fi
   createResources $NOVMS VOLSTATS VOLUME NONE NONE VOLSTIME id $CINDERTIMEOUT cinder create --image-id $IMGID --availability-zone \${VAZS[\$VAZN]} --name ${RPRE}RootVol_VM\$no $VOLTP $VOLSIZE
 }
 

--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -99,7 +99,7 @@
 # ./api_monitor.sh -n 8 -d -P -s -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMon-Notes -m urn:smn:eu-de:0ee085d22f6a413293a2c37aaa1f96fe:APIMonitor -i 100
 # (SMN is OTC specific notification service that supports sending SMS.)
 
-VERSION=1.104
+VERSION=1.105
 
 # debugging
 if test "$1" == "--debug"; then set -x; shift; fi

--- a/run_gx_scs.sh
+++ b/run_gx_scs.sh
@@ -35,6 +35,8 @@ export FROM=kurt@garloff.de
 export SWIFTCONTAINER=OS-HM-Logfiles
 # NAMESERVER
 export NAMESERVER=8.8.8.8
+# VOLUMETYPE override
+#export VOLUMETYPE="LUKS"
 
 # Assume OS_ parameters have already been sourced from some .openrc file
 # export OS_CLOUD=gx-scs-healthmgr


### PR DESCRIPTION
Should address #139.
Caveats:
`openstack server create --block-device ... volume_type=LUKS ...`
tends to fail on some environments, because cinder needs too long to deploy the image on the encrypted volume.
nova then times out waiting for cinder and the VMs end up in state error.
End user can not change the timeouts, unfortunately, the operator probably could.