### PR TITLE
Document caddy reverse proxy setup

### DIFF
--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -565,8 +565,10 @@ You can change the time interval and zoom in also by marking an interval with th
 
 The SCS providers do allow all GitHub users that belong to the SovereignCloudStack organization to get Viewer
 access to the dashboards.
+This allows to exchange experience and to get a feeling for the achievable stability.
+(Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
 
-This is achieved by adjusting the `[auth.github]` section in `/etc/grafana/grafana.ini` as follows:
+OIDC integration achieved by adjusting the `[auth.github]` section in `/etc/grafana/grafana.ini` as follows:
 
 ```ini
 [auth.github]
@@ -579,11 +581,12 @@ allow_assign_grafana_admin = false
 skip_org_role_sync = true
 ```
 
-Please replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the OAuth credentials that the SCS Org GitHub admins
+This config maps all users to the `Viewer` role regardless of their role in the GitHub Org.
+Please replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the OAuth2 credentials that the SCS Org GitHub admins
 provided to you.
+Finally, don't forgot to restart Grafana with `sudo systemctl restart grafana-server` after adjusting the config.
 
-This allows to exchange experience and to get a feeling for the achievable stability.
-(Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
+More information can be found in the [Grafana documentation for GitHub OAuth2](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/).
 
 ## Alternative approach to install and configure the dashboard behind a reverse proxy
 

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -434,8 +434,8 @@ Ensure it's started and starts at boot with `sudo systemctl enable --now caddy`.
 
 #### Allow HTTP traffic for oshm-driver
 
-Caddy needs port `80` to be able to process the Let's Encrypt HTTP challenge, so let's configure an
-appropriate security group for `oshm-driver`:
+Caddy needs TCP port `80` opened to be able to process the Let's Encrypt HTTP challenge, so let's
+configure an appropriate security group for `oshm-driver`:
 
 ```shell
 openstack security group create http

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -179,7 +179,8 @@ You can use the same project as you use for your driver VM (and possibly other w
 If your cloud API's endpoints don't use TLS certificates that are signed by an official CA, you need to provide your CA to this VM and configure it. (On a SCS Cloud-in-a-Box system, you find it on the manager node in `/etc/ssl/certs/ca-certificates.crt`. You may extract the last cert or just leave them all together.) Copy the CA file to your driver VM and ensure it's readable by the `debian` user.
 
 Add it to your `clouds.yaml`
-```
+
+```yaml
 clouds:
   CLOUDNAME:
     cacert: /PATH/TO/CACERT.CRT
@@ -378,28 +379,34 @@ sudo apt -y install telegraf
 ```
 
 In the config file `/etc/telegraf/telegraf.conf`, we enable
-```
+
+```toml
 [[inputs.influxdb_listener]]
   service_address = ":8186"
 
 [[outputs.influxdb]]
   urls = ["http://127.0.0.1:8086"]
 ```
+
 and restart the service (`sudo systemctl restart telegraf`).
 Enable it on system startup: `sudo systemctl enable telegraf`.
 
 ### InfluxDB
 
 We proceed to influxdb:
-```
+
+```shell
 sudo apt-get install influxdb
 ```
+
 In the configuration file `/etc/influxdb/influxdb.conf`, ensure that the http interface on port 8086 is enabled.
-```
+
+```toml
 [http]
   enabled = true
   bind-address = ":8086"
 ```
+
 Restart influxdb as needed with `sudo systemctl restart influxdb`.
 Also enable it on system startup: `sudo systemctl enable influxdb`.
 
@@ -609,7 +616,7 @@ Unattended-Upgrade::Origins-Pattern {
 };
 ```
 
-(This corresponds to the `o=cloudsmith/caddy/stable` in the output of `apt-cache policy`).
+(This corresponds to `o=cloudsmith/caddy/stable` in the output of `apt-cache policy`).
 
 ### sshd setup
 

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -534,6 +534,14 @@ allow_sign_up = false
 allow_org_create = false
 ```
 
+The configuration file contains secrets and should be protected such that only root and group grafana
+can read it:
+
+```shell
+sudo chown root:grafana /etc/grafana/grafana.ini
+sudo chmod 0640 /etc/grafana/grafana.ini
+```
+
 We do the OIDC connection in the section `[auth.github]` [later](#github-oidc-integration).
 
 We can now restart the service: `sudo systemctl restart grafana-server`.

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -588,41 +588,6 @@ Finally, don't forgot to restart Grafana with `sudo systemctl restart grafana-se
 
 More information can be found in the [Grafana documentation for GitHub OAuth2](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/github/).
 
-## Alternative approach to install and configure the dashboard behind a reverse proxy
-
-Install influxdb via apt: https://docs.influxdata.com/influxdb/v1/introduction/install/#installing-influxdb-oss
-Install telegraf (same apt repo as influxdb): `sudo apt update && sudo apt install telegraf`
-Install grafana: https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/#install-from-apt-repository
-
-Prepare configuration by using the config files from the repository as an alternative to doing the changes manually (as described above):
-```
-sudo cp dashboard/telegraf.conf /etc/telegraf && sudo chown root:root /etc/telegraf/telegraf.conf && sudo chmod 0644 /etc/telegraf/telegraf.conf
-sudo cp dashboard/config.toml /etc/influxdb && sudo chown root:influxdb /etc/influxdb/config.toml && sudo chmod 0640 /etc/influxdb/config.toml
-sudo cp dashboard/grafana.ini /etc/grafana && sudo chown root:grafana /etc/grafana/grafana.ini && sudo chmod 0640 /etc/grafana/grafana.ini
-```
-These config files should work as long as the versions of telegraf, influxdb and grafana don't evolve too far from the ones used in the repository. (Otherwise refer to above instructions how to tweak the default config files.)
-
-Changes to `/etc/grafana/grafana.ini` as we do tls termination at the reverse proxy:
-- set `protocol = http`
-- comment out `domain` option (? FIXME) or set it to the hostname
-- comment out `cert_*` options
-
-Also change the admin password in `grafana.ini`.
-
-Changes to `/etc/grafana/grafana.ini` if github auth should not be used yet:
-- comment out whole `[auth.github]` section for now (can be enabled later)
-
-Restart services: `sudo systemctl restart telegraf && sudo systemctl restart influxdb && sudo systemctl restart grafana-server`
-
-Configuration in grafana web gui:
-- Login to grafana `http(s)://<domain>:3000` with user admin and default password from `/etc/grafana/grafana.ini` and change password.
-- Create influxdb datasource with url `http://localhost:8086` and database name `telegraf`.
-- Finally import dashboard `dashboard/openstack-health-dashboard.json` to grafana.
-
-TODO:
-* Reverse proxy (aka ingress) with Let's Encrypt cert
-* Github auth as described above
-
 ## Maintenance
 
 The driver VM is a snowflake: A manually set up system (unless you automate all the above steps, which is possible of course) that holds data and is long-lived. As such it's important to be maintained.

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -525,7 +525,7 @@ allow_sign_up = false
 allow_org_create = false
 ```
 
-We do the OIDC connection in the section `[auth.github]` later.
+We do the OIDC connection in the section `[auth.github]` [later](#github-oidc-integration).
 
 We can now restart the service: `sudo systemctl restart grafana-server`.
 Being at it, also enable it on system startup: `sudo systemctl enable grafana-server`.
@@ -561,9 +561,29 @@ The first row of panels give a health impression; there are absolute numbers as 
 
 You can change the time interval and zoom in also by marking an interval with the mouse. Zooming out to a few months can be a very useful feature to see trends and watch e.g. your API performance, your resource creation times or the benchmarks change over the long term.
 
-#### github OIDC integration
+#### GitHub OIDC Integration
 
-The SCS providers do allow all github users that belong to the SovereignCloudStack organization to get Viewer access to the dashboards by adding a `client_id` and `client_secret` in the ``[auth.github]`` section that you request from the SCS github admins (github's oauth auth). This allows to exchange experience and to get a feeling for the achievable stability. (Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
+The SCS providers do allow all GitHub users that belong to the SovereignCloudStack organization to get Viewer
+access to the dashboards.
+
+This is achieved by adjusting the `[auth.github]` section in `/etc/grafana/grafana.ini` as follows:
+
+```ini
+[auth.github]
+enabled = true
+client_id = YOUR_CLIENT_ID
+client_secret = YOUR_CLIENT_SECRET
+allowed_organizations = ["SovereignCloudStack"]
+role_attribute_path = "'Viewer'"
+allow_assign_grafana_admin = false
+skip_org_role_sync = true
+```
+
+Please replace `YOUR_CLIENT_ID` and `YOUR_CLIENT_SECRET` with the OAuth credentials that the SCS Org GitHub admins
+provided to you.
+
+This allows to exchange experience and to get a feeling for the achievable stability.
+(Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
 
 ## Alternative approach to install and configure the dashboard behind a reverse proxy
 

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -461,7 +461,7 @@ You can change the time interval and zoom in also by marking an interval with th
 
 #### github OIDC integration
 
-The SCS providers do allow all github users that belong to the SovereignCloudStack organization to get Viewer access to the dashboards by adding a `client_id` and `client_secret` in the ``[github.auth]`` section that you request from the SCS github admins (github's oauth auth). This allows to exchange experience and to get a feeling for the achievable stability. (Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
+The SCS providers do allow all github users that belong to the SovereignCloudStack organization to get Viewer access to the dashboards by adding a `client_id` and `client_secret` in the ``[auth.github]`` section that you request from the SCS github admins (github's oauth auth). This allows to exchange experience and to get a feeling for the achievable stability. (Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
 
 ## Alternative approach to install and configure the dashboard behind a reverse proxy
 

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -568,7 +568,7 @@ access to the dashboards.
 This allows to exchange experience and to get a feeling for the achievable stability.
 (Hint: A single digit number of API call fails per week and no other failures is achievable on loaded clouds.)
 
-OIDC integration achieved by adjusting the `[auth.github]` section in `/etc/grafana/grafana.ini` as follows:
+OIDC integration is achieved by adjusting the `[auth.github]` section in `/etc/grafana/grafana.ini` as follows:
 
 ```ini
 [auth.github]

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -405,17 +405,26 @@ Also enable it on system startup: `sudo systemctl enable influxdb`.
 
 You need to tell the monitor that it should send data via telegraf to influxdb by adding the parameter `-S CLOUDNAME` to the `api_monitor.sh` call in `run_CLOUDNAME.sh`. Restart it (see above) to make the change effective immediately (and not only after 200 iterations complete).
 
-### grafana
+### Grafana
 
-#### Basic config
+#### Install Grafana
 
-Finally grafana: We (still as root) follow https://www.server-world.info/en/note?os=Debian_12&p=grafana
+We follow https://grafana.com/docs/grafana/latest/setup-grafana/installation/debian/ and setup the stable APT repository:
+
+```shell
+mkdir -p /etc/apt/keyrings
+wget -q -O - https://apt.grafana.com/gpg.key | gpg --dearmor | sudo tee /etc/apt/keyrings/grafana.gpg > /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
 ```
-sudo wget -q -O /usr/share/keyrings/grafana.key https://packages.grafana.com/gpg.key
-echo "deb [signed-by=/usr/share/keyrings/grafana.key] https://packages.grafana.com/oss/deb stable main" | sudo tee -a /etc/apt/sources.list.d/grafana.list
+
+And install it:
+
+```shell
 sudo apt update
 sudo apt -y install grafana
 ```
+
+#### Basic config
 
 The config file `/etc/grafana/grafana.ini` needs some adjustments:
 * Set the hostname in `[server]` section: `domain = health.YOURCLOUD.sovereignit.cloud`. Set the `protocol = https` if not enabled by default.

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -466,6 +466,8 @@ page because the Grafana service is not yet running (this is our next step).
 The very first request will be a bit slower, because Caddy interacts with Let's Encrypt API to create
 the TLS certificate behind the scenes.
 
+Caddy logs can be accessed with `sudo journalctl -u caddy`.
+
 ### Grafana
 
 #### Install Grafana
@@ -594,7 +596,35 @@ The driver VM is a snowflake: A manually set up system (unless you automate all 
 
 ### Unattended upgrades
 
-It is recommended to ensure maintenance updates are deployed automatically. These are unlikely to negatively impact the openstack-health-monitor. See https://wiki.debian.org/UnattendedUpgrades. If you decide against unattended upgrades, it is recommended to install updates manually regularly and especially watch out for issues that affect the services that are exposed to the world: sshd (port 22) and grafana (port 3000).
+It is recommended to ensure maintenance updates are deployed automatically. These are unlikely to negatively impact the openstack-health-monitor. See https://wiki.debian.org/UnattendedUpgrades. If you decide against unattended upgrades, it is recommended to install updates manually regularly and especially watch out for issues that affect the services that are exposed to the world: sshd (port 22) and Caddy/Grafana (port 3000).
+
+If you use `unattended-upgrades`, you should review your settings in `/etc/apt/apt.conf.d/50unattended-upgrades`,
+especially `Unattended-Upgrade::Origins-Pattern`. It controls which packages are upgraded. If you want Caddy to be
+part of the automated updates, add an entry like the following:
+
+```
+Unattended-Upgrade::Origins-Pattern {
+    // ...
+    "origin=cloudsmith/caddy/stable";
+};
+```
+
+(This corresponds to the `o=cloudsmith/caddy/stable` in the output of `apt-cache policy`).
+
+### sshd setup
+
+If you already use SSH keys to sign in to the driver VM, consider setting the following in your `/etc/ssh/sshd_config`
+if not already set:
+
+```
+PasswordAuthentication no
+```
+
+Debian's `openssh-server`, by default, is also very open about its version, so you might consider disabling this via:
+
+```
+DebianBanner no
+```
 
 ### Updating openstack-health-monitor
 

--- a/docs/Debian12-Install.md
+++ b/docs/Debian12-Install.md
@@ -366,8 +366,10 @@ After the 200 iterations, a `.psv` file (pipe-separated values) is created `Stat
 ## Data collection and dashboard
 See https://github.com/SovereignCloudStack/openstack-health-monitor/blob/main/dashboard/README.md
 
-### telegraf
+### Telegraf
+
 To install telegraf on Debian 12, we need to add the apt repository provided by InfluxData:
+
 ```bash
 sudo curl -fsSL https://repos.influxdata.com/influxdata-archive_compat.key -o /etc/apt/keyrings/influxdata-archive_compat.key
 echo "deb [signed-by=/etc/apt/keyrings/influxdata-archive_compat.key] https://repos.influxdata.com/debian stable main" | sudo tee /etc/apt/sources.list.d/influxdata.list
@@ -386,7 +388,7 @@ In the config file `/etc/telegraf/telegraf.conf`, we enable
 and restart the service (`sudo systemctl restart telegraf`).
 Enable it on system startup: `sudo systemctl enable telegraf`.
 
-### influxdb
+### InfluxDB
 
 We proceed to influxdb:
 ```


### PR DESCRIPTION
Adds documentation to use Caddy with automatic Let's Encrypt certs in front of Grafana. Caddy still uses port 3000, Grafana only listens locally on 3003.

I also tried to improve some other minor things that occured to me while I set up the OSHM for PoC WG-Cloud.

Resolves: #193