### PR TITLE
Fix/ostack10 nova notoken

### DIFF
--- a/api_monitor.sh
+++ b/api_monitor.sh
@@ -845,6 +845,8 @@ translate()
   # Some services can not easily be talked to directly
   case $ORIGCMD in
     barbican|designate|senlin) OPST=openstack;;
+    # OpenStack Client 10+ talks to keystone before nova always
+    nova) if test $OSTACKVERMAJ -ge 10; then OPST=openstack; fi;;
   esac
   if test "$CMD" == "$1"; then
     # No '-'

--- a/run_garloff.sh
+++ b/run_garloff.sh
@@ -30,7 +30,8 @@ export FROM=kurt@garloff.de
 #export AZS="muc5-a"
 # Upload (compressed) logfiles and stats to container
 #export SWIFTCONTAINER=OS-HM-Logfiles
-export DEFAULTNAMESERVER="true"
+#export DEFAULTNAMESERVER="true"
+export NAMESERVER=192.168.155.10
 
 # Assume OS_ parameters have already been sourced from some .openrc file
 # export OS_CLOUD=gx-scs-healthmgr

--- a/run_garloff.sh
+++ b/run_garloff.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+
+# Specify image names, JumpHost ideally has sfw2-snat
+# Options for the images: my openSUSE 15.2 (linux), Ubuntu 20.04 (ubuntu),
+#  openSUSE Leap 15.2 (opensuse), CentOS 8 (centos)
+# You can freely mix ...
+#export JHIMG="Ubuntu 22.04"
+export JHIMG="Debian 13"
+#export ADDJHVOLSIZE=2
+#export IMG="Ubuntu 22.04"
+#export IMG="openSUSE 16.0"
+export IMG="Debian 13"
+#export IMG="CentOS 8"
+# DEFLTUSER from image_original_user property
+#export DEFLTUSER=...
+# You can use a filter when listing images (because your catalog is huge)
+#export JHIMGFILT="--property-filter os_version=openSUSE-15.0"
+#export IMGFILT="--property-filter os_version=openSUSE-15.0"
+# ECP flavors
+#if test $OS_REGION_NAME == Kna1; then
+export JHFLAVOR=SCS-1V-2
+export FLAVOR=SCS-1L-1
+#else
+#export JHFLAVOR=1C-1GB-10GB
+#export FLAVOR=1C-1GB-10GB
+#fi
+# EMail notifications sender address
+export FROM=kurt@garloff.de
+# Only use one AZ
+#export AZS="muc5-a"
+# Upload (compressed) logfiles and stats to container
+#export SWIFTCONTAINER=OS-HM-Logfiles
+export DEFAULTNAMESERVER="true"
+
+# Assume OS_ parameters have already been sourced from some .openrc file
+# export OS_CLOUD=gx-scs-healthmgr
+
+export EMAIL_PARAM=${EMAIL_PARAM:-"scs@garloff.de"}
+
+# Ensure that all commands find custom CA, place the custom CiaB CA cert here:
+# export OS_CACERT=/etc/ca-cert-ciab.crt
+
+# Notifications & Alarms (pass as list, arrays can't be exported)
+ALARM_EMAIL_ADDRESSES="scs@garloff.de"
+NOTE_EMAIL_ADDRESSES="scs@garloff.de"
+#ALARM_EMAIL_ADDRESSES="scs@garloff.de scs-monitoring@plusserver.com"
+#NOTE_EMAIL_ADDRESSES="scs@garloff.de"
+export ALARM_EMAIL_ADDRESSES NOTE_EMAIL_ADDRESSES
+
+export EXTSEARCH=public1
+
+# Terminate early on auth error
+openstack server list >/dev/null || exit 1
+
+echo "Finding resources from previous runs to clean up ..."
+# Find Floating IPs
+FIPLIST=""
+FIPS=$(openstack floating ip list -f value -c ID)
+for fip in $FIPS; do
+	FIP=$(openstack floating ip show $fip | grep -o "APIMonitor_[0-9]*")
+	if test -n "$FIP"; then FIPLIST="${FIPLIST}${FIP}_
+"; fi
+done
+FIPLIST=$(echo "$FIPLIST" | grep -v '^$' | sort -u)
+# Cleanup previous interrupted runs
+SERVERS=$(openstack server  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+KEYPAIR=$(openstack keypair list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+VOLUMES=$(openstack volume  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+NETWORK=$(openstack network list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+LOADBAL=$(openstack loadbalancer list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+ROUTERS=$(openstack router  list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+SECGRPS=$(openstack security group list | grep -o "APIMonitor_[0-9]*_" | sort -u)
+echo CLEANUP: FIPs $FIPLIST Servers $SERVERS Keypairs $KEYPAIR Volumes $VOLUMES Networks $NETWORK LoadBalancers $LOADBAL Routers $ROUTERS SecGrps $SECGRPS
+for ENV in $FIPLIST; do
+  echo "******************************"
+  echo "CLEAN $ENV"
+  bash ./api_monitor.sh -o -T -q -c CLEANUP $ENV
+  echo "******************************"
+done
+TOCLEAN=$(echo "$SERVERS
+$KEYPAIR
+$VOLUMES
+$NETWORK
+$LOADBAL
+$ROUTERS
+$SECGRPS
+" | grep -v '^$' | sort -u)
+for ENV in $TOCLEAN; do
+  echo "******************************"
+  echo "CLEAN $ENV"
+  #bash ./api_monitor.sh -o -T -q -LL -c CLEANUP $ENV
+  bash ./api_monitor.sh -o -q -LL -c CLEANUP $ENV
+  echo "******************************"
+done
+
+#bash ./api_monitor.sh -c -x -d -n 8 -l last.log -e $EMAIL_PARAM -S -i 9
+#exec api_monitor.sh -o -C -D -N 2 -n 8 -s -e sender@domain.org "$@"
+#exec ./api_monitor.sh -O -C -D -N 2 -n 8 -s -L -b -B -M -a 2 -t -T -R -X "$@"
+exec ./api_monitor.sh -O -C -D -N 2 -n 8 -s -LO -b -B -M -a 2 -t -T -R -X -S garloffcloud "$@"
+#exec ./api_monitor.sh -O -C -D -N 2 -n 8 -s -b -B -M -a 2 -t -T -R -S ciab "$@"
+


### PR DESCRIPTION
With the `api_monitor.sh -O` option, we grab a token once and then talk to the endpoints directly. This saves a roundtrip to keystone ...
Since openstackclient-10/sdk-4.18 (or maybe earlier), this does no longer work for the compute endpoint -- it wants a connection to keystone always, like we also need for a few other calls.
This optimization becomes less and less valid, I guess ...
For now, just add an exception for nova.